### PR TITLE
Import IObjectEvent from zope.interface.interfaces 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+1.1 (2021-04-08)
+----------------
+
+- Add compatibility with latest zope.component versions
+
 1.0 (2014-12-28)
 ----------------
 

--- a/repoze/folder/interfaces.py
+++ b/repoze/folder/interfaces.py
@@ -1,4 +1,4 @@
-from zope.component.interfaces import IObjectEvent
+from zope.interface.interfaces import IObjectEvent
 from zope.interface import Interface
 from zope.interface import Attribute
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ docs_require = ['Sphinx', 'repoze.sphinx.autointerface']
 testing_extras = ['nose', 'coverage']
 
 setup(name='repoze.folder',
-      version='1.0',
+      version='1.1',
       description='A ZODB folder implementation with object events',
       long_description=README + '\n\n' +  CHANGES,
       classifiers=[


### PR DESCRIPTION
zope.component 5.0 (latest release) removed IObjectEvent and some other deprecated interfaces, more info here: https://github.com/zopefoundation/zope.component/issues/59

This little change ensures repoze.folder keeps working with recent zope.component releases.

(and those *deprecated* interfaces have been in the zope.interface package for a while anyway)

Regards.